### PR TITLE
`site.url` と `site.github` を _config.yml に設定

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,6 @@
+url: 'https://wckansai2016.github.io'
 baseurl: '/wordpress-document'
+
+github:
+  id: wckansai2016
+  repo: wordpress-document

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,9 +44,9 @@
     <footer class="siteFooter">
       <p>Organized by <a href="http://wordcamp-kansai.connpass.com/event/34312/">WordCamp Kansai 2016 documentation Hands-on team</a>. / licensed under <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">the GPLv2</a> or later.</p>
       <p><a href="http://wordcamp-kansai.connpass.com/event/34312/">WordCamp Kansai 2016 ドキュメンテーションハンズオンチーム</a>が運営しています。 / ライセンスは <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPLv2</a> またはそれ以降に準拠します。</p>
-      <a href="https://github.com/wckansai2016/wordpress-document">GitHub で見る</a>
+      <a href="https://github.com/{{ site.github.id }}/{{ site.github.repo }}">GitHub で見る</a>
     </footer>
 
-    
+
   </body>
 </html>


### PR DESCRIPTION
リポジトリを移管したときのことを考慮して、`site.url` と リポジトリ情報を `_config.yml` に設定しておき、そちらを使うようにします。
