### PR TITLE
.jekyll-cache ディレクトリを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Jekyll
 _site
+.jekyll-cache
 
 # Node.js
 node_modules/


### PR DESCRIPTION
Jekyll 4 以降で `jekyll serve` 実行時に  `.jekyll-cache` ディレクトリが生成されるため、 gitに含まれないように除外しています。
https://jekyllrb.com/docs/upgrading/3-to-4/